### PR TITLE
Add airview-compliance-ui to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "apps/airview-demo",
     "packages/airview-mock-server",
     "packages/airview-cms-api",
+    "packages/airview-compliance-ui",
     "apps/airview-api-demo"
   ],
   "lint-staged": {


### PR DESCRIPTION
Adds missing `airview-compliance-ui` to main `package.json` workspaces key.