### PR TITLE
Add prepare script for airview-cms-api

### DIFF
--- a/packages/airview-cms-api/package.json
+++ b/packages/airview-cms-api/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding this means we can depend on a local directory in the wrapper package.json, and not have to explicitly "npm run build" in the api dir before doing the wrapper npm install...