### PR TITLE
221 refactor control overview

### DIFF
--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-group.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-group.js
@@ -1,14 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
-import Accordion from "@material-ui/core/Accordion";
-import AccordionSummary from "@material-ui/core/AccordionSummary";
-import AccordionDetails from "@material-ui/core/AccordionDetails";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import Typography from "@material-ui/core/Typography";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Typography from "@mui/material/Typography";
 
 export function ControlOverviewGroup({ groupTitle, id, onChange, children }) {
-  const classes = useControlOverviewGroupStyles();
+  const classes = controlOverviewGroupStyles();
 
   const handleOnChange = (event, expanded) => {
     if (expanded) onChange(id);
@@ -16,22 +15,19 @@ export function ControlOverviewGroup({ groupTitle, id, onChange, children }) {
 
   return (
     <Accordion
-      classes={{
-        root: classes.overviewGroup,
-        expanded: classes.overviewGroupExpanded,
+      sx={{
+        "&.MuiAccordion-root": classes.overviewGroup,
       }}
       onChange={handleOnChange}
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
-        className={classes.overviewGroupSummary}
+        sx={classes.overviewGroupSummary}
       >
-        <Typography className={classes.overviewGroupTitle}>
-          {groupTitle}
-        </Typography>
+        <Typography sx={classes.overviewGroupTitle}>{groupTitle}</Typography>
       </AccordionSummary>
 
-      <AccordionDetails className={classes.overviewGroupChildren}>
+      <AccordionDetails sx={classes.overviewGroupChildren}>
         {children}
       </AccordionDetails>
     </Accordion>
@@ -45,7 +41,7 @@ ControlOverviewGroup.propTypes = {
   children: PropTypes.node,
 };
 
-const useControlOverviewGroupStyles = makeStyles((theme) => {
+function controlOverviewGroupStyles() {
   return {
     overviewGroup: {
       boxShadow: "none",
@@ -55,23 +51,23 @@ const useControlOverviewGroupStyles = makeStyles((theme) => {
       "&:before": {
         display: "none",
       },
-      "&$overviewGroupExpanded": {
+      "&.Mui-expanded": {
         margin: "auto",
       },
-      "&:not(:first-of-type) $overviewGroupSummary": {
+      "&:not(:first-of-type)": {
         borderTop: "1px solid rgba(0, 0, 0, .125)",
       },
     },
     overviewGroupExpanded: {},
     overviewGroupSummary: {},
     overviewGroupTitle: {
-      fontSize: theme.typography.pxToRem(16),
-      fontWeight: theme.typography.fontWeightMedium,
+      fontSize: 16,
+      fontWeight: "medium",
     },
     overviewGroupChildren: {
       display: "block",
-      padding: theme.spacing(0, 0, 0, 0),
+      padding: 0,
       borderTop: "1px solid rgba(0, 0, 0, .125)",
     },
   };
-});
+}

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-header.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-header.js
@@ -1,15 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
-import Toolbar from "@material-ui/core/Toolbar";
-import Typography from "@material-ui/core/Typography";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
 
 export function ControlOverviewHeader({ title }) {
-  const classes = useControlOverviewHeaderStyles();
+  const classes = controlOverviewHeaderStyles();
 
   return (
-    <Toolbar className={classes.header} disableGutters>
-      <Typography variant="h6" component="p">
+    <Toolbar sx={classes.header} disableGutters>
+      <Typography
+        sx={{ fontWeight: 600, fontSize: "18px" }}
+        variant="h6"
+        component="p"
+      >
         {title}
       </Typography>
     </Toolbar>
@@ -20,10 +23,13 @@ ControlOverviewHeader.propTypes = {
   title: PropTypes.string,
 };
 
-const useControlOverviewHeaderStyles = makeStyles((theme) => {
+function controlOverviewHeaderStyles() {
   return {
     header: {
-      padding: theme.spacing(1, 2),
+      paddingTop: 1,
+      paddingBottom: 1,
+      paddingRight: 2,
+      paddingLeft: 2,
     },
   };
-});
+}

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-item-detail.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-item-detail.js
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
-import Grid from "@material-ui/core/Grid";
-import Button from "@material-ui/core/Button";
-import Typography from "@material-ui/core/Typography";
-import OpenInNewIcon from "@material-ui/icons/OpenInNew";
+import Grid from "@mui/material/Grid";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import Box from "@mui/material/Box";
 
 export function ControlOverviewItemDetail({
   control,
@@ -12,20 +12,18 @@ export function ControlOverviewItemDetail({
   controlAction,
   lifecycle,
 }) {
-  const classes = useControlOverviewItemDetailStyles();
+  const classes = controlOverviewItemDetailStyles();
 
   return (
     <Grid container spacing={2}>
       <Grid item xs={9}>
-        <div className={classes.itemDetails}>
-          <div className={classes.itemDetail}>
-            <div className={classes.itemDetailLeftContent}>
-              <Typography className={classes.itemDetailTitle}>
-                Control:
-              </Typography>
-            </div>
+        <Box component="div">
+          <Box component="div" sx={classes.itemDetail}>
+            <Box component="div" sx={classes.itemDetailLeftContent}>
+              <Typography sx={classes.itemDetailTitle}>Control:</Typography>
+            </Box>
 
-            <div className={classes.itemDetailRightContent}>
+            <Box component="div" sx={classes.itemDetailRightContent}>
               <Typography variant="body2">{control.name}</Typography>
 
               <Button
@@ -34,21 +32,19 @@ export function ControlOverviewItemDetail({
                 href={control.url}
                 color="primary"
                 endIcon={<OpenInNewIcon />}
-                className={classes.itemDetailAction}
+                sx={classes.itemDetailAction}
               >
                 View
               </Button>
-            </div>
-          </div>
+            </Box>
+          </Box>
 
-          <div className={classes.itemDetail}>
-            <div className={classes.itemDetailLeftContent}>
-              <Typography className={classes.itemDetailTitle}>
-                Frameworks:
-              </Typography>
-            </div>
+          <Box component="div" sx={classes.itemDetail}>
+            <Box component="div" sx={classes.itemDetailLeftContent}>
+              <Typography sx={classes.itemDetailTitle}>Frameworks:</Typography>
+            </Box>
 
-            <div className={classes.itemDetailRightContent}>
+            <Box component="div" sx={classes.itemDetailRightContent}>
               {frameworks.map((framework) => (
                 <Button
                   size="small"
@@ -56,42 +52,40 @@ export function ControlOverviewItemDetail({
                   href={framework.url}
                   color="primary"
                   endIcon={<OpenInNewIcon />}
-                  className={classes.itemDetailAction}
+                  sx={classes.itemDetailAction}
                   key={framework.name}
                 >
                   {framework.name}
                 </Button>
               ))}
-            </div>
-          </div>
+            </Box>
+          </Box>
 
-          <div className={classes.itemDetail}>
-            <div className={classes.itemDetailLeftContent}>
-              <Typography className={classes.itemDetailTitle}>
+          <Box component="div" sx={classes.itemDetail}>
+            <Box component="div" sx={classes.itemDetailLeftContent}>
+              <Typography sx={classes.itemDetailTitle}>
                 Control Action:
               </Typography>
-            </div>
+            </Box>
 
-            <div className={classes.itemDetailRightContent}>
+            <Box component="div" sx={classes.itemDetailRightContent}>
               <Typography variant="body2">{controlAction}</Typography>
-            </div>
-          </div>
+            </Box>
+          </Box>
 
-          <div className={classes.itemDetail}>
-            <div className={classes.itemDetailLeftContent}>
-              <Typography className={classes.itemDetailTitle}>
-                Lifecycle:
-              </Typography>
-            </div>
+          <Box component="div" sx={classes.itemDetail}>
+            <Box component="div" sx={classes.itemDetailLeftContent}>
+              <Typography sx={classes.itemDetailTitle}>Lifecycle:</Typography>
+            </Box>
 
-            <div className={classes.itemDetailRightContent}>
+            <Box component="div" sx={classes.itemDetailRightContent}>
               <Typography variant="body2">{lifecycle}</Typography>
-            </div>
-          </div>
-        </div>
+            </Box>
+          </Box>
+        </Box>
       </Grid>
 
-      <Grid item xs={3} className={classes.actions}>
+      <Grid item xs={3} sx={classes.actions}>
         <Button
           variant="contained"
           disableElevation
@@ -123,26 +117,30 @@ ControlOverviewItemDetail.propTypes = {
   lifecycle: PropTypes.string,
 };
 
-const useControlOverviewItemDetailStyles = makeStyles((theme) => {
+function controlOverviewItemDetailStyles() {
   return {
     itemDetail: {
       display: "flex",
       justifyContent: "space-between",
       alignItems: "center",
-      padding: theme.spacing(1, 0),
+      paddingTop: 1,
+      paddingBottom: 1,
+      paddingRight: 0,
+      paddingLeft: 0,
 
       "&:first-of-type": {
         paddingTop: 0,
       },
 
       "&:not(:last-of-type)": {
-        borderBottom: `1px solid ${theme.palette.divider}`,
+        borderBottom: 1,
+        borderBottomColor: "divider",
       },
     },
 
     itemDetailLeftContent: {
       flex: "0 0 auto",
-      paddingRight: theme.spacing(1),
+      paddingRight: 1,
     },
 
     itemDetailRightContent: {
@@ -151,24 +149,24 @@ const useControlOverviewItemDetailStyles = makeStyles((theme) => {
       alignItems: "center",
       justifyContent: "flex-end",
       flexWrap: "wrap",
-      paddingLeft: theme.spacing(1),
+      paddingLeft: 1,
 
       "& > *:not(:last-child)": {
-        marginRight: theme.spacing(1),
+        marginRight: 1,
       },
     },
 
     itemDetailTitle: {
-      fontSize: theme.typography.pxToRem(14),
-      fontWeight: theme.typography.fontWeightBold,
+      fontSize: 14,
+      fontWeight: "bold",
     },
 
     itemDetailAction: {
-      fontSize: theme.typography.pxToRem(12),
+      fontSize: 12,
 
       "& .MuiSvgIcon-root": {
-        fontSize: theme.typography.pxToRem(14),
+        fontSize: 14,
       },
     },
   };
-});
+}

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-item-resources.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-item-resources.js
@@ -1,30 +1,28 @@
 import React, { useMemo, useState } from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
-import Table from "@material-ui/core/Table";
-import TableBody from "@material-ui/core/TableBody";
-import TableCell from "@material-ui/core/TableCell";
-import TableContainer from "@material-ui/core/TableContainer";
-import TableHead from "@material-ui/core/TableHead";
-import TableRow from "@material-ui/core/TableRow";
-import TableSortLabel from "@material-ui/core/TableSortLabel";
-import Paper from "@material-ui/core/Paper";
-import Toolbar from "@material-ui/core/Toolbar";
-import Typography from "@material-ui/core/Typography";
-import Tooltip from "@material-ui/core/Tooltip";
-import IconButton from "@material-ui/core/IconButton";
-import FilterListIcon from "@material-ui/icons/FilterList";
-import Menu from "@material-ui/core/Menu";
-import MenuItem from "@material-ui/core/MenuItem";
-import ListItemIcon from "@material-ui/core/ListItemIcon";
-import ListItemText from "@material-ui/core/ListItemText";
-import Checkbox from "@material-ui/core/Checkbox";
-import Box from "@material-ui/core/Box";
-import SettingsIcon from "@material-ui/icons/Settings";
-import CheckIcon from "@material-ui/icons/Check";
-import ClearIcon from "@material-ui/icons/Clear";
-import InfoIcon from "@material-ui/icons/Info";
-import clsx from "clsx";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import Paper from "@mui/material/Paper";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import Tooltip from "@mui/material/Tooltip";
+import IconButton from "@mui/material/IconButton";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Checkbox from "@mui/material/Checkbox";
+import Box from "@mui/material/Box";
+import SettingsIcon from "@mui/icons-material/Settings";
+import CheckIcon from "@mui/icons-material/Check";
+import ClearIcon from "@mui/icons-material/Clear";
+import InfoIcon from "@mui/icons-material/Info";
 import dayjs from "dayjs";
 
 export function ControlOverviewItemResources({
@@ -32,7 +30,7 @@ export function ControlOverviewItemResources({
   onManageResourceClick,
   onViewResourceEvidence,
 }) {
-  const classes = useControlOverviewItemResourcesStyles();
+  const classes = controlOverviewItemResourcesStyles();
 
   const [anchorEl, setAnchorEl] = useState(null);
   const [activeFilters, setActiveFilters] = useState([]);
@@ -126,9 +124,9 @@ export function ControlOverviewItemResources({
   };
 
   return (
-    <Paper variant="outlined" className={classes.container}>
+    <Paper variant="outlined" sx={classes.container}>
       <TableContainer>
-        <Toolbar variant="dense" className={classes.toolbar}>
+        <Toolbar variant="dense" sx={{ "&.MuiToolbar-root": classes.toolbar }}>
           <Typography variant="subtitle2" component="p">
             Resources
           </Typography>
@@ -155,7 +153,6 @@ export function ControlOverviewItemResources({
                 keepMounted
                 open={Boolean(anchorEl)}
                 onClose={handleOnFilterClose}
-                getContentAnchorEl={null}
                 anchorOrigin={{
                   vertical: 8,
                   horizontal: 28,
@@ -176,16 +173,17 @@ export function ControlOverviewItemResources({
                       dense
                       key={filter}
                     >
-                      <ListItemIcon classes={{ root: classes.filterItem }}>
+                      <ListItemIcon
+                        sx={{ "&.MuiListItemIcon-root": classes.filterItem }}
+                      >
                         <Checkbox
                           checked={activeFilters.includes(filter)}
                           color="default"
                           disableRipple
                           tabIndex={-1}
                           size="small"
-                          classes={{
-                            root: classes.filterCheckbox,
-                            checked: classes.filterCheckboxChecked,
+                          sx={{
+                            "&.MuiCheckbox-root": classes.filterCheckbox,
                           }}
                           inputProps={{
                             "aria-labelledby": filter,
@@ -210,7 +208,7 @@ export function ControlOverviewItemResources({
         </Toolbar>
 
         <Table size="small">
-          <TableHead className={classes.tableHead}>
+          <TableHead sx={classes.tableHead}>
             <TableRow>
               <TableCell>Type</TableCell>
               <TableCell>Resource</TableCell>
@@ -224,14 +222,15 @@ export function ControlOverviewItemResources({
                     aria-label="Sort by last seen"
                   >
                     Last seen
-                    <span
-                      className={classes.visuallyHidden}
+                    <Box
+                      component="span"
+                      sx={classes.visuallyHidden}
                       aria-label="Sorting order"
                     >
                       {lastSeenOrder === "desc"
                         ? "Last seen sorted descending"
                         : "Last seen sorted ascending"}
-                    </span>
+                    </Box>
                   </TableSortLabel>
                 ) : (
                   "Last seen"
@@ -244,7 +243,7 @@ export function ControlOverviewItemResources({
             </TableRow>
           </TableHead>
 
-          <TableBody className={classes.tableBody}>
+          <TableBody sx={classes.tableBody}>
             {processedResourcesData.map((resource) => {
               return (
                 <TableRow key={resource.id}>
@@ -255,14 +254,15 @@ export function ControlOverviewItemResources({
                     {dayjs(resource.lastSeen).format("MMM D YYYY h:mm A")}
                   </TableCell>
                   <TableCell>
-                    <span
-                      className={clsx(
-                        classes.statusLabel,
-                        classes[getStatusLabelClassName(resource.status)]
-                      )}
+                    <Box
+                      component="span"
+                      sx={{
+                        ...classes.statusLabel,
+                        ...classes[getStatusLabelClassName(resource.status)],
+                      }}
                     >
                       {resource.status}
-                    </span>
+                    </Box>
                   </TableCell>
                   <TableCell>
                     {resource.pending ? (
@@ -332,15 +332,15 @@ ControlOverviewItemResources.propTypes = {
   onViewResourceEvidence: PropTypes.func.isRequired,
 };
 
-const useControlOverviewItemResourcesStyles = makeStyles((theme) => {
+function controlOverviewItemResourcesStyles() {
   return {
     container: {
-      marginTop: theme.spacing(2),
+      marginTop: 2,
     },
     toolbar: {
-      paddingLeft: theme.spacing(2),
-      paddingRight: theme.spacing(2),
-      backgroundColor: theme.palette.grey[50],
+      paddingLeft: 2,
+      paddingRight: 2,
+      backgroundColor: "grey.50",
     },
     filterItem: { minWidth: 30 },
     filterCheckbox: {
@@ -363,7 +363,7 @@ const useControlOverviewItemResourcesStyles = makeStyles((theme) => {
       width: 1,
     },
     tableHead: {
-      backgroundColor: theme.palette.grey[50],
+      backgroundColor: "grey.50",
     },
     tableBody: {
       "& > tr:last-of-type > td": {
@@ -371,32 +371,32 @@ const useControlOverviewItemResourcesStyles = makeStyles((theme) => {
       },
     },
     statusLabel: {
-      ...theme.typography.body2,
+      ..."typography.body2",
       textTransform: "capitalize",
-      fontSize: theme.typography.pxToRem(12),
-      fontWeight: theme.typography.fontWeightBold,
-      border: `1px solid ${theme.palette.primary.main}`,
-      borderRadius: theme.shape.borderRadius,
+      fontSize: 12,
+      fontWeight: "bolc",
+      border: `1px solid primary.main`,
+      borderRadius: 1,
       padding: "2px 8px",
       whiteSpace: "nowrap",
     },
 
     statusLabelMonitoring: {
-      backgroundColor: theme.palette.success.main,
-      borderColor: theme.palette.success.dark,
-      color: theme.palette.common.white,
+      backgroundColor: "success.main",
+      borderColor: "success.dark",
+      color: "common.white",
     },
 
     statusLabelNonCompliant: {
-      backgroundColor: theme.palette.error.main,
-      borderColor: theme.palette.error.dark,
-      color: theme.palette.common.white,
+      backgroundColor: "error.main",
+      borderColor: "error.dark",
+      color: "common.white",
     },
 
     statusLabelExempt: {
-      backgroundColor: theme.palette.grey[300],
-      borderColor: theme.palette.grey[400],
-      color: theme.palette.grey[800],
+      backgroundColor: "grey.300",
+      borderColor: "grey.400",
+      color: "grey.800",
     },
   };
-});
+}

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-item.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-item.js
@@ -1,14 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
-import Accordion from "@material-ui/core/Accordion";
-import AccordionSummary from "@material-ui/core/AccordionSummary";
-import AccordionDetails from "@material-ui/core/AccordionDetails";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import Typography from "@material-ui/core/Typography";
-import Tooltip from "@material-ui/core/Tooltip";
-import Box from "@material-ui/core/Box";
-import ErrorIcon from "@material-ui/icons/Error";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Typography from "@mui/material/Typography";
+import Tooltip from "@mui/material/Tooltip";
+import Box from "@mui/material/Box";
+import ErrorIcon from "@mui/icons-material/Error";
 
 export function ControlOverviewItem({
   id,
@@ -19,9 +18,7 @@ export function ControlOverviewItem({
   children,
   onChange,
 }) {
-  const classes = useControlOverviewItemStyles({
-    severity: severity.toLowerCase(),
-  });
+  const classes = controlOverviewItemStyles(severity.toLowerCase());
 
   const handleOnChange = (event, expanded) => {
     if (expanded) onChange(id);
@@ -29,15 +26,20 @@ export function ControlOverviewItem({
 
   return (
     <Accordion
-      classes={{
-        root: classes.overviewItem,
-        expanded: classes.overviewItemExpanded,
+      sx={{
+        "&.MuiAccordion-root": classes.overviewItem,
       }}
       onChange={handleOnChange}
     >
       <AccordionSummary
+        sx={{
+          "& .MuiAccordionSummary-expandIconWrapper": {
+            padding: "12px",
+            marginRight: "-12px",
+          },
+          "&.Mui-expanded": { borderBottom: "1px solid rgba(0, 0, 0, .125)" },
+        }}
         expandIcon={<ExpandMoreIcon />}
-        className={classes.overviewItemSummary}
       >
         <Box display="flex" flexGrow={1} justifyContent="space-between">
           <Box paddingRight={1} display="flex" alignItems="center">
@@ -45,7 +47,7 @@ export function ControlOverviewItem({
               title={`Severity: ${severity.toLowerCase()}`}
               placement="bottom-start"
             >
-              <ErrorIcon fontSize="small" className={classes.severityStatus} />
+              <ErrorIcon fontSize="small" sx={classes.severityStatus} />
             </Tooltip>
 
             <Typography variant="body2">{name}</Typography>
@@ -53,21 +55,21 @@ export function ControlOverviewItem({
 
           <Box paddingLeft={1} display="flex" alignItems="center">
             <Tooltip title={`Applied`} placement="bottom-end">
-              <span className={classes.infoLabel}>
+              <Box component="span" sx={classes.infoLabel}>
                 <Typography variant="body2">{applied}</Typography>
-              </span>
+              </Box>
             </Tooltip>
 
             <Tooltip title={`Exempt`} placement="bottom-end">
-              <span className={classes.infoLabel}>
+              <Box component="span" sx={classes.infoLabel}>
                 <Typography variant="body2">{exempt}</Typography>
-              </span>
+              </Box>
             </Tooltip>
           </Box>
         </Box>
       </AccordionSummary>
 
-      <AccordionDetails className={classes.overviewItemDetail}>
+      <AccordionDetails sx={classes.overviewItemDetail}>
         {children}
       </AccordionDetails>
     </Accordion>
@@ -84,7 +86,7 @@ ControlOverviewItem.propTypes = {
   onChange: PropTypes.func,
 };
 
-const useControlOverviewItemStyles = makeStyles((theme) => {
+function controlOverviewItemStyles(severity) {
   return {
     overviewItem: {
       width: "100%",
@@ -95,14 +97,14 @@ const useControlOverviewItemStyles = makeStyles((theme) => {
       "&:before": {
         display: "none",
       },
-      "&$overviewItemExpanded": {
+      "&.Mui-expanded": {
         margin: "auto",
       },
-      "&:not(:first-of-type) $overviewItemSummary": {
+      "&:not(:first-of-type)": {
         borderTop: "1px solid rgba(0, 0, 0, .125)",
       },
     },
-    overviewItemExpanded: {},
+    overviewItemExpanded: { margin: "auto" },
     overviewItemSummary: {
       "$overviewItemExpanded &": {
         borderBottom: "1px solid rgba(0, 0, 0, .125)",
@@ -110,24 +112,24 @@ const useControlOverviewItemStyles = makeStyles((theme) => {
     },
     overviewItemDetail: {
       display: "block",
-      paddingTop: theme.spacing(2),
+      paddingTop: 2,
     },
-    severityStatus: (props) => {
+    severityStatus: () => {
       const getBackgroundColor = (severity) => {
         let backgroundColor;
 
         switch (severity) {
           case "low":
-            backgroundColor = theme.palette.success.main;
+            backgroundColor = "success.main";
             break;
           case "medium":
-            backgroundColor = theme.palette.warning.main;
+            backgroundColor = "warning.main";
             break;
           case "high":
-            backgroundColor = theme.palette.error.main;
+            backgroundColor = "error.main";
             break;
           default:
-            backgroundColor = theme.palette.grey["500"];
+            backgroundColor = "grey.500";
         }
 
         return backgroundColor;
@@ -136,25 +138,29 @@ const useControlOverviewItemStyles = makeStyles((theme) => {
       return {
         width: 26,
         height: 26,
-        padding: 4,
+        padding: "4px",
         borderRadius: "100%",
         color: "#fff",
         display: "inline-block",
-        backgroundColor: getBackgroundColor(props.severity),
+        backgroundColor: getBackgroundColor(severity),
         fontSize: "16px",
-        marginRight: theme.spacing(2),
+        marginRight: 2,
       };
     },
+
     infoLabel: {
       display: "inline-block",
-      border: `1px solid ${theme.palette.primary.main}`,
-      borderRadius: theme.shape.borderRadius,
-      padding: theme.spacing(0, 1),
-      color: theme.palette.text.primary,
+      border: 1,
+      borderRadius: 1,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingRight: 1,
+      paddingLeft: 1,
+      color: "text.primary",
 
       "&:not(:last-of-type)": {
-        marginRight: theme.spacing(1),
+        marginRight: 1,
       },
     },
   };
-});
+}

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-loading-indicator.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-loading-indicator.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Box from "@material-ui/core/Box";
-import CircularProgress from "@material-ui/core/CircularProgress";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
 
 export function ControlOverviewLoadingIndicator({ padding = false }) {
   return (

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-resource-evidence-viewer.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-resource-evidence-viewer.js
@@ -6,7 +6,7 @@ import {
   DialogContent,
   DialogActions,
   Button,
-} from "@material-ui/core";
+} from "@mui/material";
 //import { MarkdownContent } from "../markdown-content";
 
 export function ControlOverviewResourceEvidenceViewer({

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview-resource-manager.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview-resource-manager.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
 import {
   Dialog,
   DialogTitle,
@@ -9,13 +8,12 @@ import {
   Button,
   Divider,
   Typography,
-} from "@material-ui/core";
-import DayjsUtils from "@date-io/dayjs";
+  Box,
+  TextField,
+} from "@mui/material";
 import dayjs from "dayjs";
-import {
-  MuiPickersUtilsProvider,
-  KeyboardDatePicker,
-} from "@material-ui/pickers";
+import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { WorkingOverlay } from "./working-overlay";
 
 export function ControlOverviewResourceManager({
@@ -25,7 +23,7 @@ export function ControlOverviewResourceManager({
   onResourceExemptionDelete,
   onResourceExemptionSave,
 }) {
-  const classes = useStyles();
+  const classes = controlOverviewResoueceManagerStyles();
 
   const [revisedExpiryDate, setRevisedExpiryDate] = useState(
     resourceData?.expires
@@ -84,22 +82,14 @@ export function ControlOverviewResourceManager({
       </DialogTitle>
 
       <DialogContent dividers>
-        <Typography
-          variant="h6"
-          component="h3"
-          className={classes.sectionHeader}
-        >
+        <Typography variant="h6" component="h3" sx={classes.sectionHeader}>
           Ticket:
         </Typography>
         <Typography variant="body2">{resourceData.ticket}</Typography>
 
-        <Divider className={classes.sectionDivider} />
+        <Divider sx={classes.sectionDivider} />
 
-        <Typography
-          variant="h6"
-          component="h3"
-          className={classes.sectionHeader}
-        >
+        <Typography variant="h6" component="h3" sx={classes.sectionHeader}>
           Expires:
         </Typography>
 
@@ -108,48 +98,39 @@ export function ControlOverviewResourceManager({
           current expiry date.
         </Typography>
 
-        <MuiPickersUtilsProvider utils={DayjsUtils}>
-          <KeyboardDatePicker
-            name="reviewDate"
-            disableToolbar
-            variant="inline"
-            inputVariant="outlined"
-            format="DD/MM/YYYY"
-            margin="normal"
-            size="small"
-            fullWidth
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <DatePicker
+            inputFormat="DD/MM/YYYY"
             disablePast
-            invalidDateMessage="Invalid date, please format as DD/MM/YYYY"
-            minDateMessage="Date should not be a past date"
             value={revisedExpiryDate}
             onChange={(date) => setRevisedExpiryDate(date)}
-            KeyboardButtonProps={{
-              "aria-label": "change date",
-              size: "small",
-              edge: "end",
-            }}
-            required
+            renderInput={(params) => (
+              <TextField
+                required
+                fullWidth
+                margin="normal"
+                size="small"
+                {...params}
+              />
+            )}
             disabled={working}
+            PopperProps={{ placement: "auto" }}
           />
-        </MuiPickersUtilsProvider>
+        </LocalizationProvider>
 
-        <Divider className={classes.sectionDivider} />
+        <Divider sx={classes.sectionDivider} />
 
-        <Typography
-          variant="h6"
-          component="h3"
-          className={classes.sectionHeader}
-        >
+        <Typography variant="h6" component="h3" sx={classes.sectionHeader}>
           Resources:
         </Typography>
 
-        <ul className={classes.resourcesList}>
+        <Box component="ul" sx={classes.resourcesList}>
           {resourceData.resources.map((resource) => (
             <Typography component="li" variant="body2" key={resource}>
               {resource}
             </Typography>
           ))}
-        </ul>
+        </Box>
       </DialogContent>
 
       <DialogActions>
@@ -188,18 +169,22 @@ export function ControlOverviewResourceManager({
   );
 }
 
-const useStyles = makeStyles((theme) => ({
-  sectionHeader: {
-    fontSize: theme.typography.pxToRem(15),
-  },
-  sectionDivider: {
-    margin: theme.spacing(2, 0),
-  },
-  resourcesList: {
-    margin: 0,
-    padding: "0 0 0 18px",
-  },
-}));
+function controlOverviewResoueceManagerStyles() {
+  return {
+    sectionHeader: {
+      fontSize: 15,
+      fontWeight: 600,
+    },
+    sectionDivider: {
+      marginTop: 2,
+      marginBottom: 2,
+    },
+    resourcesList: {
+      margin: 0,
+      padding: "0 0 0 18px",
+    },
+  };
+}
 
 ControlOverviewResourceManager.propTypes = {
   open: PropTypes.bool.isRequired,

--- a/packages/airview-compliance-ui/src/features/control-overview/control-overview.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/control-overview.js
@@ -1,9 +1,9 @@
 import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
-import { useTheme } from "@material-ui/core/styles";
-import Paper from "@material-ui/core/Paper";
-import Box from "@material-ui/core/Box";
-import Skeleton from "@material-ui/lab/Skeleton";
+import { useTheme } from "@mui/material/styles";
+import Paper from "@mui/material/Paper";
+import Box from "@mui/material/Box";
+import { Skeleton } from "@mui/material";
 import { ControlOverviewHeader } from "./control-overview-header";
 import { ControlOverviewGroup } from "./control-overview-group";
 import { ControlOverviewItem } from "./control-overview-item";

--- a/packages/airview-compliance-ui/src/features/control-overview/working-overlay.js
+++ b/packages/airview-compliance-ui/src/features/control-overview/working-overlay.js
@@ -1,39 +1,40 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@material-ui/core/styles";
-import clsx from "clsx";
-import CircularProgress from "@material-ui/core/CircularProgress";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
 
 export function WorkingOverlay({ open, color, ...rest }) {
-  const styles = useWorkingOverlayStyles({ color });
+  const classes = workingOverlayStyles(color);
 
-  const { className, ...otherProps } = rest;
+  const { ...otherProps } = rest;
 
   if (!open) return null;
 
   return (
-    <div className={clsx(styles.root, className)} {...otherProps}>
-      <CircularProgress classes={{ circle: styles.circle }} />
-    </div>
+    <Box component="div" sx={classes.root} {...otherProps}>
+      <CircularProgress sx={classes.circle} />
+    </Box>
   );
 }
 
-const useWorkingOverlayStyles = makeStyles((theme) => ({
-  root: {
-    position: "absolute",
-    backgroundColor: "rgba(0,0,0, 0.1)",
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  circle: ({ color }) => ({
-    color: color ?? theme.palette.primary.main,
-  }),
-}));
+function workingOverlayStyles(color) {
+  return {
+    root: {
+      position: "absolute",
+      backgroundColor: "rgba(0,0,0, 0.1)",
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    circle: {
+      color: color ?? "primary.main",
+    },
+  };
+}
 
 WorkingOverlay.propTypes = {
   /**


### PR DESCRIPTION
refactor the component control overview to the latest material ui 5
replace the `makeStyle` hooks by `sx` prop
replace the deprecated `material-ui/picker` by `ui/x-date-pickers`