### PR TITLE
#254: Migrate Breadcrumb component to airview-ui, add story and docs

### DIFF
--- a/packages/airview-ui/src/features/breadcrumb/breadcrumb.js
+++ b/packages/airview-ui/src/features/breadcrumb/breadcrumb.js
@@ -1,0 +1,78 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Breadcrumbs, Typography, Skeleton, Link } from "@mui/material";
+import { isLinkInternal } from "../../util";
+
+export function Breadcrumb({
+  links,
+  currentRoute,
+  loading,
+  fetching,
+  linkComponent,
+  sx,
+}) {
+  return (
+    <Breadcrumbs
+      maxItems={5}
+      aria-label="Breadcrumb"
+      aria-live="polite"
+      aria-busy={loading}
+      sx={{
+        ...(fetching && {
+          opacity: 0.5,
+          pointerEvents: "none",
+        }),
+        ...sx,
+      }}
+    >
+      {loading
+        ? [...Array(5)].map((item, index) => (
+            <Skeleton key={index} sx={{ width: 110 }} />
+          ))
+        : links?.map((link) => (
+            <Link
+              underline="hover"
+              to={link.url}
+              target={isLinkInternal(link.url) ? "_self" : "_blank"}
+              key={link.url}
+              component={linkComponent}
+            >
+              {link.label}
+            </Link>
+          ))}
+      {!loading && <Typography>{currentRoute}</Typography>}
+    </Breadcrumbs>
+  );
+}
+
+Breadcrumb.propTypes = {
+  /**
+   * Presents the breadcrumbs in a loading state
+   */
+  loading: PropTypes.bool.isRequired,
+  /**
+   * Renders the breadcrumbs in a fetching state
+   */
+  fetching: PropTypes.bool.isRequired,
+  /**
+   * Sets the available interactive link items
+   */
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  /**
+   * Allows the passing of a Link Component (i.e React Router Link)
+   */
+  linkComponent: PropTypes.any,
+  /**
+   * Sets the current route (the current page)
+   */
+  currentRoute: PropTypes.string.isRequired,
+  /**
+   * Allows passthrough of SX styling props (see Material UI SX docs for more info)
+   */
+  sx: PropTypes.object,
+};

--- a/packages/airview-ui/src/features/breadcrumb/index.js
+++ b/packages/airview-ui/src/features/breadcrumb/index.js
@@ -1,0 +1,1 @@
+export { Breadcrumb } from "./breadcrumb";

--- a/packages/airview-ui/src/features/index.js
+++ b/packages/airview-ui/src/features/index.js
@@ -5,3 +5,4 @@ export * from "./menu";
 export * from "./page-title";
 export * from "./aside-and-main";
 export * from "./styled-wysiwyg";
+export * from "./breadcrumb";

--- a/packages/airview-ui/src/stories/breadcrumb/breadcrumb.doc.md
+++ b/packages/airview-ui/src/stories/breadcrumb/breadcrumb.doc.md
@@ -1,0 +1,17 @@
+The Breadcrumb component is used to help a user visualize a page's location within the hierarchical structure of a website, and allow navigation up to any of its "ancestors".
+
+## Breadcrumb States
+
+The Breadcrumb can be rendered in three states, namely:
+
+- **Loading:** The data to render the Breadcrumb is not yet ready, a loading UI will present to the user to indicate the state
+- **Fetching:** The data has been loaded previously and is now updating, the opacity of the UI will change to indicate a disabled state. All user interaction with the Breadcrumb will be disabled.
+- **Loaded:** The data is in a ready state, the user can freely interact with the Breadcrumb component
+
+## Importing the component
+
+You can import the Breadcrumb component as a named import from the airview-ui library
+
+```javascript
+import { Breadcrumb } from "airview-ui";
+```

--- a/packages/airview-ui/src/stories/breadcrumb/breadcrumb.stories.js
+++ b/packages/airview-ui/src/stories/breadcrumb/breadcrumb.stories.js
@@ -1,0 +1,119 @@
+import React from "react";
+import { Breadcrumb } from "../../features";
+import Documentation from "./breadcrumb.doc.md";
+
+export default {
+  title: "Components/Breadcrumb",
+  component: Breadcrumb,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: Documentation,
+      },
+    },
+  },
+};
+
+function Template(args) {
+  return <Breadcrumb {...args} />;
+}
+
+Template.args = {
+  currentRoute: "Current Route",
+};
+
+Template.argsTypes = {
+  linkComponent: {
+    control: false,
+  },
+  sx: {
+    control: false,
+  },
+};
+
+export const Loading = Template.bind({});
+
+Loading.args = {
+  ...Template.args,
+  loading: true,
+  fetching: false,
+  links: [],
+  currentRoute: "",
+};
+
+Loading.argTypes = {
+  ...Template.argsTypes,
+};
+
+export const FetchingWithoutCollapsedBreadcrumbs = Template.bind({});
+
+FetchingWithoutCollapsedBreadcrumbs.args = {
+  ...Template.args,
+  loading: false,
+  fetching: true,
+  links: [
+    {
+      label: "Route One",
+      url: "/",
+    },
+    {
+      label: "Route Two",
+      url: "/",
+    },
+    {
+      label: "Route Three",
+      url: "/",
+    },
+    {
+      label: "Route Four",
+      url: "/",
+    },
+  ],
+  currentRoute: "Current Route",
+};
+
+FetchingWithoutCollapsedBreadcrumbs.argTypes = {
+  ...Template.argsTypes,
+};
+
+export const FetchingWithCollapsedBreadcrumbs = Template.bind({});
+
+FetchingWithCollapsedBreadcrumbs.args = {
+  ...FetchingWithoutCollapsedBreadcrumbs.args,
+  links: [
+    ...FetchingWithoutCollapsedBreadcrumbs.args.links,
+    {
+      label: "Route Five",
+      url: "/",
+    },
+  ],
+};
+
+FetchingWithCollapsedBreadcrumbs.argTypes = {
+  ...Template.argsTypes,
+};
+
+export const LoadedWithoutCollapsedBreadcrumbs = Template.bind({});
+
+LoadedWithoutCollapsedBreadcrumbs.args = {
+  ...Template.args,
+  loading: false,
+  fetching: false,
+  links: [...FetchingWithoutCollapsedBreadcrumbs.args.links],
+};
+
+LoadedWithoutCollapsedBreadcrumbs.argTypes = {
+  ...Template.argsTypes,
+};
+
+export const LoadedWithCollapsedBreadcrumbs = Template.bind({});
+
+LoadedWithCollapsedBreadcrumbs.args = {
+  ...LoadedWithoutCollapsedBreadcrumbs.args,
+  links: [...FetchingWithCollapsedBreadcrumbs.args.links],
+};
+
+LoadedWithCollapsedBreadcrumbs.argTypes = {
+  ...Template.argsTypes,
+};


### PR DESCRIPTION
Migrates the `Breadcrumb` component from the legacy airview application to `airview-ui` package.

closes airwalk-digital/airview-issues#254