### PR TITLE
Add missing exports from lib

### DIFF
--- a/packages/airview-compliance-ui/src/features/index.js
+++ b/packages/airview-compliance-ui/src/features/index.js
@@ -1,2 +1,5 @@
+export * from "./application-tile";
 export * from "./compliance-table";
 export * from "./control-overview";
+export * from "./icon-chip";
+export * from "./progress-bar";

--- a/packages/airview-compliance-ui/src/index.js
+++ b/packages/airview-compliance-ui/src/index.js
@@ -1,1 +1,1 @@
-export { ComplianceTable, ControlOverview } from "@features";
+export * from "@features";


### PR DESCRIPTION
Adds missing exports for recent additions to the lib:

- application-tile
- icon-chip
- progress-bar