### PR TITLE
Fix component prop type warning on ApplicationTileCallToActionButton

### DIFF
--- a/packages/airview-compliance-ui/src/features/application-tile/application-tile-call-to-action-button.js
+++ b/packages/airview-compliance-ui/src/features/application-tile/application-tile-call-to-action-button.js
@@ -46,6 +46,6 @@ function useStyles() {
 ApplicationTileCallToActionButton.propTypes = {
   label: PropTypes.string.isRequired,
   classNames: PropTypes.string,
-  component: PropTypes.node,
+  component: PropTypes.any,
   linkProps: PropTypes.object,
 };


### PR DESCRIPTION
Fixes warning on "component" prop for `ApplicationTileCallToActionButton` component