### PR TITLE
#270 append timestamp to entry ID

### DIFF
--- a/packages/airview-cms/src/features/cms/content-creator/prepare-entry-payload.js
+++ b/packages/airview-cms/src/features/cms/content-creator/prepare-entry-payload.js
@@ -22,7 +22,7 @@ export function prepareEntryPayload() {
 
     const entryId = `${selectedEntryCollection}/${slugifyString(
       entryMetaData.title
-    )}`;
+    )}_${Date.now().toString(36)}`;
 
     const { additionalFiles } = collections[selectedEntryCollection];
 


### PR DESCRIPTION
Adds support for non-unique entry creation by appending a UUID (timestamp) to the entry ID string on creation of new content

closes airwalk-digital/airview-issues#270