### PR TITLE
#260: Specify node versions for all airview packages and demo

### DIFF
--- a/apps/airview-demo/package.json
+++ b/apps/airview-demo/package.json
@@ -2,6 +2,9 @@
   "name": "airview-demo",
   "version": "0.4.0",
   "private": true,
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "airview",
   "version": "0.0.0",
   "description": "",
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "devDependencies": {
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/airview-cms-api/package.json
+++ b/packages/airview-cms-api/package.json
@@ -2,6 +2,9 @@
   "name": "airview-cms-api",
   "version": "0.0.0",
   "description": "",
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "main": "dist/index.js",
   "files": [
     "./dist"

--- a/packages/airview-cms/package.json
+++ b/packages/airview-cms/package.json
@@ -2,6 +2,9 @@
   "name": "airview-cms",
   "version": "0.0.0",
   "description": "",
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "main": "dist/index.js",
   "files": [
     "./dist"

--- a/packages/airview-compliance-ui/package.json
+++ b/packages/airview-compliance-ui/package.json
@@ -2,6 +2,9 @@
   "name": "airview-compliance-ui",
   "version": "0.0.0",
   "description": "",
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "main": "dist/index.js",
   "files": [
     "./dist"

--- a/packages/airview-mock-server/package.json
+++ b/packages/airview-mock-server/package.json
@@ -2,6 +2,9 @@
   "name": "airview-mock-server",
   "version": "0.0.0",
   "description": "",
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "main": "dist/airview-mock-server.esm.min.js",
   "files": [
     "./dist"

--- a/packages/airview-ui/package.json
+++ b/packages/airview-ui/package.json
@@ -2,6 +2,9 @@
   "name": "airview-ui",
   "version": "0.0.0",
   "description": "",
+  "engines": {
+    "node": ">=16.15.1 <17.0.0"
+  },
   "main": "dist/index.js",
   "files": [
     "./dist"


### PR DESCRIPTION
Adds 'engines' key to 'package.json' files for all airview packages and demo - specifying supported min and max versions of node.js

closes airwalk-digital/airview-issues#260