### PR TITLE
#277: Force MDEditor to run in light mode

### DIFF
--- a/packages/airview-cms/src/features/cms/body-editor/markdown-editor.js
+++ b/packages/airview-cms/src/features/cms/body-editor/markdown-editor.js
@@ -82,43 +82,40 @@ export function MarkdownEditor() {
 
   if (cmsEnabled && !protectedBranch) {
     return (
-      <MDEditor
-        value={markdownContent}
-        onChange={handleOnChange}
-        autoFocus={false}
-        preview="edit"
-        commands={[
-          titleSelector,
-          commands.bold,
-          commands.italic,
-          commands.strikethrough,
-          commands.hr,
-          commands.quote,
-          commands.code,
-          commands.codeBlock,
-          commands.unorderedListCommand,
-          commands.orderedListCommand,
-          commands.checkedListCommand,
-          commands.link,
-          commands.group([], markdownImagePicker),
-        ]}
-      />
+      <div data-color-mode="light">
+        <MDEditor
+          value={markdownContent}
+          onChange={handleOnChange}
+          autoFocus={false}
+          preview="edit"
+          commands={[
+            titleSelector,
+            commands.bold,
+            commands.italic,
+            commands.strikethrough,
+            commands.hr,
+            commands.quote,
+            commands.code,
+            commands.codeBlock,
+            commands.unorderedListCommand,
+            commands.orderedListCommand,
+            commands.checkedListCommand,
+            commands.link,
+            commands.group([], markdownImagePicker),
+          ]}
+        />
+      </div>
     );
   }
 
   return (
-    <MDEditor.Markdown
-      source={markdownContent}
-      previewOptions={{
-        rehypePlugins: [[rehypeSanitize]],
-      }}
-    />
+    <div data-color-mode="light">
+      <MDEditor.Markdown
+        source={markdownContent}
+        previewOptions={{
+          rehypePlugins: [[rehypeSanitize]],
+        }}
+      />
+    </div>
   );
 }
-
-/*
-body: {
-  _index.md: base64 String,
-  cat.jpg: base64 String
-}
-*/

--- a/packages/airview-cms/src/features/cms/body-editor/markdown-editor.js
+++ b/packages/airview-cms/src/features/cms/body-editor/markdown-editor.js
@@ -52,22 +52,6 @@ function imagePicker(dispatch) {
   };
 }
 
-const titleSelector = commands.group(
-  [
-    commands.title1,
-    commands.title2,
-    commands.title3,
-    commands.title4,
-    commands.title5,
-    commands.title6,
-  ],
-  {
-    name: "title",
-    groupName: "title",
-    buttonProps: { "aria-label": "Insert title" },
-  }
-);
-
 export function MarkdownEditor() {
   const dispatch = useDispatch();
   const markdownContent = useSelector(selectBodyEditorData);
@@ -89,7 +73,21 @@ export function MarkdownEditor() {
           autoFocus={false}
           preview="edit"
           commands={[
-            titleSelector,
+            commands.group(
+              [
+                commands.title1,
+                commands.title2,
+                commands.title3,
+                commands.title4,
+                commands.title5,
+                commands.title6,
+              ],
+              {
+                name: "title",
+                groupName: "title",
+                buttonProps: { "aria-label": "Insert title" },
+              }
+            ),
             commands.bold,
             commands.italic,
             commands.strikethrough,


### PR DESCRIPTION
- Forces the MDEditor used in the MarkdownEditor component of airview-cms to always run in light mode (regardless of user settings)
- Fixes the title selector widget on the MDEditor component replacing selected string of text

closes airwalk-digital/airview-issues#277
closes airwalk-digital/airview-issues#233