### PR TITLE
#314: Fix header indentation on Markdown content

### DIFF
--- a/packages/airview-ui/src/features/styled-wysiwyg/styled-wysiwyg.js
+++ b/packages/airview-ui/src/features/styled-wysiwyg/styled-wysiwyg.js
@@ -68,6 +68,10 @@ export function StyledWysiwyg({
             color: "inherit",
           },
 
+          "& .octicon-link": {
+            display: "none",
+          },
+
           "& p": {
             marginY: 2,
           },


### PR DESCRIPTION
PR applies required CSS style to remove indentation on Markdown headers.

closes airwalk-digital/airview-issues#314