### PR TITLE
Lint, build and test all airview packages on pull request to main

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@ node_modules
 dist
 storybook-static
 public
+build
+coverage

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+storybook-static
+public

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -1,0 +1,36 @@
+name: Lint Build and Test
+on:
+  pull_request:
+    branches: ["main"]
+jobs:
+  lint_build_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Project
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Lint JavaScript
+        run: npm run lint
+      - name: Check formatting
+        run: npm run check-formatting
+      - name: Build airview-cms
+        run: npm run build --workspace=packages/airview-cms
+      - name: Build airview-mock-server
+        run: npm run build --workspace=packages/airview-mock-server
+      - name: Build airview-ui
+        run: npm run build --workspace=packages/airview-ui
+      - name: Smoke test airview-ui Storybook
+        run: npm run storybook --workspace=packages/airview-ui -- --smoke-test --ci
+      - name: Build airview-compliance-ui
+        run: npm run build --workspace=packages/airview-compliance-ui
+      - name: Smoke test airview-ui Storybook
+        run: npm run storybook --workspace=packages/airview-compliance-ui -- --smoke-test --ci
+      - name: Build airview-cms-api
+        run: npm run build --workspace=packages/airview-cms-api
+      - name: Build airview-demo
+        run: npm run build --workspace=apps/airview-demo -- --env=CI

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+storybook-static
+public

--- a/apps/airview-demo/src/reportWebVitals.js
+++ b/apps/airview-demo/src/reportWebVitals.js
@@ -1,6 +1,6 @@
-const reportWebVitals = onPerfEntry => {
+const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);
       getFCP(onPerfEntry);

--- a/apps/airview-demo/src/setupTests.js
+++ b/apps/airview-demo/src/setupTests.js
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier": "^2.6.2"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "lint": "eslint 'packages/**/*.{js, jsx, ts, tsx}' 'apps/**/*.{js, jsx, ts, tsx}'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "lint": "eslint 'packages/**/*.{js, jsx, ts, tsx}' 'apps/**/*.{js, jsx, ts, tsx}'"
+    "lint": "eslint 'packages/**/*.{js, jsx, ts, tsx}' 'apps/**/*.{js, jsx, ts, tsx}'",
+    "check-formatting": "prettier --check --ignore-unknown 'packages' 'apps'",
+    "fix-formatting": "npm run check-formatting -- --write"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds minimal QA checks in an attempt to prevent regressions by building all airview packages within the `packages` directory. Also builds the `airview-demo` within the `apps` directory.

**Note:** 
- Ideally we'd look to spin up the demo and run a smoke test, due to a limitation in time this has not been completed, but will hopefully be covered by end-to-end tests at a later date
- Source written in TypeScript is not currently being linted using ESLint, nor will it be checked using the pre-commit hook. The docs to support TypeScript and ESLint are not particularly clear. One to review at a later date.

closes airwalk-digital/airview-issues#320