### PR TITLE
#310: Remove heading links in Markdown content

### DIFF
--- a/packages/airview-ui/src/features/styled-wysiwyg/styled-wysiwyg.js
+++ b/packages/airview-ui/src/features/styled-wysiwyg/styled-wysiwyg.js
@@ -69,9 +69,10 @@ export function StyledWysiwyg({
           },
 
           "& .octicon-link": {
-            visibility: "visible",
-            color: theme.palette.grey[500],
-            marginRight: "5px",
+            display: "none",
+            // visibility: "visible",
+            // color: theme.palette.grey[500],
+            // marginRight: "5px",
           },
 
           "& p": {


### PR DESCRIPTION
Removes the icon to grab a header hash link from a Markdown content (due to airview instances not supporting hash linking).

closes airwalk-digital/airview-issues#310