### PR TITLE
Add clearer message, fix isProtected branch

### DIFF
--- a/deployment/airview-cms-api-aws-lambda-wrapper/src/api/putContentEntity.ts
+++ b/deployment/airview-cms-api-aws-lambda-wrapper/src/api/putContentEntity.ts
@@ -28,13 +28,20 @@ export function putContentEntity() {
 
     const cookie = event.headers["Cookie"];
     const author = getAuthorDetails(cookie);
-    await cmsBackend.setContent({
-      id: entityId,
-      branchName: branch,
-      baseSha: baseSha,
-      content: body,
-      author,
-    });
+    try {
+      await cmsBackend.setContent({
+        id: entityId,
+        branchName: branch,
+        baseSha: baseSha,
+        content: body,
+        author,
+      });
+    } catch (err) {
+      return {
+        statusCode: 400,
+        body: "Failed to persist content. Please check branch protection policies and that the branch has not been committed to since begining edits.",
+      };
+    }
 
     return {
       statusCode: 201,

--- a/packages/airview-cms-api/src/github-client.ts
+++ b/packages/airview-cms-api/src/github-client.ts
@@ -226,11 +226,13 @@ export class GithubClient implements GitClient {
         `Bad status getting branches ${resp.status} ${await resp.text()})`
       );
     const data: any = await resp.json();
-    const mapped = data.map((item: any) => ({
-      name: item.name,
-      sha: item.commit.sha,
-      protected: item.protected,
-    }));
+    const mapped = data.map(
+      (item: any): GitBranch => ({
+        name: item.name,
+        sha: item.commit.sha,
+        isProtected: item.protected,
+      })
+    );
     return mapped;
   }
 


### PR DESCRIPTION
Closes airwalk-digital/airview-issues#321 
Closes airwalk-digital/airview-issues#317

This is more of a tactical workaround to bubble up errors to the client but not particularly gracefully within the code. We need to come up with a better solution with regards to this, and better error handling as part of the points mentioned in  airwalk-digital/airview-issues#324

