### PR TITLE
#329: Update publish packages action to include airview-html-to-pdf-util

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           npm version --no-git-tag-version --workspace=packages/airview-compliance-ui ${GITHUB_REF##*/}
           npm publish --workspace=packages/airview-compliance-ui/
+      - name: Publish airview-html-to-pdf-util
+        run: |
+          npm version --no-git-tag-version --workspace=packages/airview-html-to-pdf-util ${GITHUB_REF##*/}
+          npm publish --workspace=packages/airview-html-to-pdf-util/
 
       - name: Publish airview-cms-api-aws-lambda-wrapper
         run: |

--- a/packages/airview-html-to-pdf-util/package.json
+++ b/packages/airview-html-to-pdf-util/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds required step to publish airview-html-to-pdf-util as part of `publish-packages` action