### PR TITLE
Allow API to return > 30 branches

### DIFF
--- a/packages/airview-cms-api/src/github-client.ts
+++ b/packages/airview-cms-api/src/github-client.ts
@@ -220,10 +220,10 @@ export class GithubClient implements GitClient {
 
   async getBranches(): Promise<GitBranch[]> {
     const linkParser = (linkHeader: string) => {
-      let re = /<([^\?]+\?[a-z]+=([\d]+))>;[\s]*rel="next"/g;
+      let re = /<.*(?=>; rel=\"next\")/g;
       let arrRes: any = [];
       while ((arrRes = re.exec(linkHeader)) !== null) {
-        return arrRes[1];
+        return arrRes[0].split("<").slice(-1)[0];
       }
       return null;
     };

--- a/packages/airview-cms-api/src/github-client.ts
+++ b/packages/airview-cms-api/src/github-client.ts
@@ -246,7 +246,7 @@ export class GithubClient implements GitClient {
       const next: string = linkParser(resp.headers.get("Link")!);
       return { mapped, next };
     };
-    let link = `${this.githubRepoURI()}/branches`;
+    let link = `${this.githubRepoURI()}/branches?per_page=100`;
     let final: GitBranch[] = [];
 
     while (link) {


### PR DESCRIPTION
Modifies 'get branches' to recursively fetch next links branches.

Closes airwalk-digital/airview-issues#337

Will need to be considered when looking at airwalk-digital/airview-issues#311.